### PR TITLE
Fix params hash handling

### DIFF
--- a/lib/WWW/DuckDuckGo.rakumod
+++ b/lib/WWW/DuckDuckGo.rakumod
@@ -27,7 +27,6 @@ method zeroclickinfo_request_base($for_uri, @query_fields) {
     my $query = @query_fields.join(' ');
     $query = uri-escape($query);
     my $uri = URI.new($for_uri);
-    my %params = %($!params);
     # FIXME: when it'll work with Perl 6 URI module;
     # $uri.query_param( q => $query); is much more safe.
     $uri ~= "?q=$query";
@@ -35,8 +34,8 @@ method zeroclickinfo_request_base($for_uri, @query_fields) {
     $uri ~= "&kp=-1" if $!safeoff;
     $uri ~= "&no_redirect=1";
     $!html ?? ($uri ~= "&no_html=0") !! ($uri ~= "&no_html=1");
-    for %params.keys {
-        $uri ~= "&$_=%params{$_}";
+    for $!params.kv -> $k, $v {
+        $uri ~= "&$k=$v";
     };
     $uri
 }


### PR DESCRIPTION
When calling the `zci` method, I get the following error:
```
Cannot look up attributes in a Hash type object. Did you forget a '.new'?
  in method zeroclickinfo_request_base at /home/sam/.raku/sources/E28B4258B5E0B34BAE9DEBE9C034E872E2F62ADD (WWW::DuckDuckGo) line 32
  in method zeroclickinfo_request at /home/sam/.raku/sources/E28B4258B5E0B34BAE9DEBE9C034E872E2F62ADD (WWW::DuckDuckGo) line 53
  in method zeroclickinfo at /home/sam/.raku/sources/E28B4258B5E0B34BAE9DEBE9C034E872E2F62ADD (WWW::DuckDuckGo) line 67
  in method zci at /home/sam/.raku/sources/E28B4258B5E0B34BAE9DEBE9C034E872E2F62ADD (WWW::DuckDuckGo) line 21
  in block <unit> at <unknown file> line 1
  in any <main> at /usr/share/perl6/runtime/perl6.moarvm line 1
  in any <entry> at /usr/share/perl6/runtime/perl6.moarvm line 1
```
The issue appears to be that WWW::DuckDuckGo tries to copy the `params` attribute into a seperate variable. There doesn't seem to be any reason to do this over just reading the from `params` attribute directly, so this PR corrects that.